### PR TITLE
Throw a more helpful error if Buffer is undefined in decoder

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -1123,13 +1123,19 @@ function decode(jpegData, userOpts = {}) {
     if(decoder.comments.length > 0) {
       image["comments"] = decoder.comments;
     }
-  } catch (err){
-    if (err instanceof RangeError){
+  } catch (err) {
+    if (err instanceof RangeError) {
       throw new Error("Could not allocate enough memory for the image. " +
                       "Required: " + bytesNeeded);
-    } else {
-      throw err;
+    } 
+    
+    if (err instanceof ReferenceError) {
+      if (err.message === "Buffer is not defined") {
+        throw new Error("Buffer is not globally defined in this environment. " +
+                        "Consider setting useTArray to true");
+      }
     }
+    throw err;
   }
 
   decoder.copyToImageData(image, opts.formatAsRGBA);


### PR DESCRIPTION
Hopefully this will help anyone else that tries to decode a jpeg in a non-Node environment such as react-native, avoiding a repeat of https://github.com/jpeg-js/jpeg-js/issues/92